### PR TITLE
Update isort hook in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
           - --safe
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.1
+    rev: 5.12.0
     hooks:
       - id: isort
         files: \.py$


### PR DESCRIPTION
Fixes ci #68. it failed to run because of an `issort` version. after this fix, pre-commit suggests changes to your latest commit instead of "an unexpected error"